### PR TITLE
Plan-6: Feat 이벤트 구독, 발행 시스템 추가

### DIFF
--- a/MonsterFaction/MonsterFaction/MonsterFaction/GameWorld/World.cs
+++ b/MonsterFaction/MonsterFaction/MonsterFaction/GameWorld/World.cs
@@ -1,5 +1,6 @@
 ﻿using MonsterFaction.GameWorld.WorldObject;
 using MonsterFaction.GameWorld.WorldObject.Shape;
+using MonsterFaction.SystemEvents;
 using System.Collections.Generic;
 using System.Numerics;
 
@@ -37,6 +38,7 @@ namespace MonsterFaction.GameWorld
                         Vector2.Zero
                     );
             testObjects.Add(player);
+            EventBroker.PublishEvent(new CreateEvent { ObjectId = 1});
             return player;
         }
 

--- a/MonsterFaction/MonsterFaction/MonsterFaction/Program.cs
+++ b/MonsterFaction/MonsterFaction/MonsterFaction/Program.cs
@@ -1,4 +1,5 @@
 ﻿using MonsterFaction.GameWorld;
+using MonsterFaction.SystemEvents;
 using System;
 
 namespace MonsterFaction
@@ -24,6 +25,7 @@ namespace MonsterFaction
         private TimeSpan lag = TimeSpan.Zero;
 
         private readonly World gameWorld = new();
+        private readonly EventSubscriber<CreateEvent> eventSubscriber = new (EventType.CREATE);
         public IDrawableWorld GameWorld => gameWorld;
 
         public Game()
@@ -47,6 +49,13 @@ namespace MonsterFaction
 
             // render();
         }
+        private void printEvent()
+        {
+            foreach (CreateEvent systemEvent in eventSubscriber.FetchAll())
+            {
+                Logger.Log.Information($"[CreateEvent]. ObjectId: {systemEvent.ObjectId}");
+            }
+        }
 
         public void Start()
         {
@@ -56,6 +65,7 @@ namespace MonsterFaction
         public void Update()
         {
             gameWorld.Update();
+            printEvent();
         }
     }
 }

--- a/MonsterFaction/MonsterFaction/MonsterFaction/SystemEvents/EventBroker.cs
+++ b/MonsterFaction/MonsterFaction/MonsterFaction/SystemEvents/EventBroker.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+
+namespace MonsterFaction.SystemEvents
+{
+    public class EventBroker
+    {
+        private static readonly Dictionary<EventType, List<Queue<IEvent>>> eventChannels = new(); 
+
+        public static void PublishEvent(IEvent systemEvent)
+        {
+            var channel = eventChannels[systemEvent.EventType];
+            foreach(var eventQueue in channel)
+            {
+                eventQueue.Enqueue(systemEvent);
+            }
+        }
+
+        public static void Subscribe(EventType eventType, Queue<IEvent> eventQueue)
+        {
+            if (!eventChannels.ContainsKey(eventType))
+            {
+                eventChannels[eventType] = new();
+            }
+            eventChannels[eventType].Add(eventQueue);
+        }
+    }
+}

--- a/MonsterFaction/MonsterFaction/MonsterFaction/SystemEvents/EventSubscriber.cs
+++ b/MonsterFaction/MonsterFaction/MonsterFaction/SystemEvents/EventSubscriber.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+
+namespace MonsterFaction.SystemEvents
+{
+    public class EventSubscriber<T> where T : IEvent
+    {
+        private Queue<IEvent> eventQueue = new Queue<IEvent>();
+
+        public EventSubscriber(EventType eventType)
+        {
+            EventBroker.Subscribe(eventType, eventQueue);
+        }
+
+        public List<T> FetchAll()
+        {
+            List<T> list = new List<T>();
+            while (eventQueue.Count > 0)
+            {
+                list.Add((T)eventQueue.Dequeue());
+            }
+            return list;
+        }
+    }
+
+}

--- a/MonsterFaction/MonsterFaction/MonsterFaction/SystemEvents/EventType.cs
+++ b/MonsterFaction/MonsterFaction/MonsterFaction/SystemEvents/EventType.cs
@@ -1,0 +1,7 @@
+﻿namespace MonsterFaction.SystemEvents
+{
+    public enum EventType
+    {
+        CREATE, DELETE
+    }
+}

--- a/MonsterFaction/MonsterFaction/MonsterFaction/SystemEvents/IEvent.cs
+++ b/MonsterFaction/MonsterFaction/MonsterFaction/SystemEvents/IEvent.cs
@@ -1,0 +1,29 @@
+﻿namespace MonsterFaction.SystemEvents
+{
+    public interface IEvent 
+    {
+        public EventType EventType { get; init; }
+    }
+
+    public readonly struct CreateEvent : IEvent
+    {
+        public readonly EventType EventType { get; init; }
+        public readonly int ObjectId { get; init; }
+        public CreateEvent(int ObjectId)
+        {
+            this.EventType = EventType.CREATE;
+            this.ObjectId = ObjectId;
+        }
+    }
+
+    public readonly struct DeleteEvent : IEvent
+    {
+        public readonly EventType EventType { get; init; }
+        public readonly int ObjectId { get; init; }
+        public DeleteEvent(int ObjectId)
+        {
+            this.EventType = EventType.DELETE;
+            this.ObjectId = ObjectId;
+        }
+    }
+}

--- a/MonsterFaction/MonsterFaction/MonsterFactionTests1/SystemEvents/EventBrokerTests.cs
+++ b/MonsterFaction/MonsterFaction/MonsterFactionTests1/SystemEvents/EventBrokerTests.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MonsterFaction.SystemEvents;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MonsterFaction.SystemEvents.Tests
+{
+    [TestClass()]
+    public class EventTests
+    {
+        [TestMethod()]
+        public void PublishEventTest()
+        {
+            var subsciber = new EventSubscriber<CreateEvent>(EventType.CREATE);
+            var testEvent1 = new CreateEvent { ObjectId = 10 };
+            var testEvent2 = new CreateEvent { ObjectId = 20 };
+            EventBroker.PublishEvent(testEvent1);
+            EventBroker.PublishEvent(testEvent2);
+            Assert.IsTrue(
+                subsciber.FetchAll().SequenceEqual(new List<CreateEvent>() { testEvent1, testEvent2 })
+                );
+            Assert.AreEqual(0, subsciber.FetchAll().Count());
+        }
+
+        [TestMethod()]
+        public void MultiSubscriberTest()
+        {
+            var subsciber1 = new EventSubscriber<CreateEvent>(EventType.CREATE);
+            var testEvent1 = new CreateEvent { ObjectId = 10 };
+            EventBroker.PublishEvent(testEvent1);
+
+            var testEvent2 = new CreateEvent { ObjectId = 20 };
+            var subsciber2 = new EventSubscriber<CreateEvent>(EventType.CREATE);
+            EventBroker.PublishEvent(testEvent2);
+
+            Assert.IsTrue(
+                subsciber1.FetchAll().SequenceEqual(new List<CreateEvent>() { testEvent1, testEvent2 })
+                );
+            Assert.IsTrue(
+                subsciber2.FetchAll().SequenceEqual(new List<CreateEvent>() { testEvent2 })
+                );
+        }
+    }
+}


### PR DESCRIPTION
이벤트 시스템을 만들었습니다.
- 이벤트 발행: EventBroker 의 static 메서드인 Publish 로 어디서든지 발행 가능.
- 이벤트 구독: EventSubscriber 를 생성하면 EventBroker 를 자동으로 구독. 발행된 메시지를 FetchAll 로 꺼낼 수 있음.

커밋 단위로 리뷰 봐주시면 편할거예요~